### PR TITLE
fixed version checker

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -5,7 +5,6 @@ const migration = require('../migration');
 
 function start(path, options) {
   const newVersion = '1.0.0';
-  const previousVersion = '4';
   const dependencyPrefix = '@totvs/';
   const dependenciesExcluded = ['@totvs/thf-kendo', '@totvs/thf-theme-kendo', '@totvs/mobile-theme'];
 
@@ -17,7 +16,7 @@ function start(path, options) {
     migration.fileReader.setup(options);
 
     const checkVersion = migration.changePortinariVersion(
-      packagePath, dependencyPrefix, previousVersion, newVersion, dependenciesExcluded);
+      packagePath, dependencyPrefix, newVersion, dependenciesExcluded);
 
     if (checkVersion) {
       migration.convertDirectory(srcPath);

--- a/src/migration/index.js
+++ b/src/migration/index.js
@@ -28,15 +28,16 @@ function convertDirectory(directory) {
 function changePortinariVersion(
   packageJsonFile,
   dependencyPrefix,
-  previousVersion,
   newVersion,
   dependenciesExcluded) {
+
+  const regex = /^\^[1-9][0-9]|[4-9]/g;
 
   const packageJson = fileReader.getFileSync(packageJsonFile);
 
   for (const dependency in packageJson.dependencies) {
-    
-    if (dependency.startsWith(dependencyPrefix) && !packageJson.dependencies[dependency].startsWith(previousVersion)) {
+
+    if (dependency.startsWith(dependencyPrefix) && !regex.test(packageJson.dependencies[dependency])) {
 
       return false;
     

--- a/src/migration/keyWords.json
+++ b/src/migration/keyWords.json
@@ -2165,6 +2165,6 @@
   "thf-toaster-base": "po-toaster-base",
   "thf-ui": "portinari-ui",
   "thf-theme/": "style/",
-  "thf-theme-default": "portinari-theme-default",
+  "thf-theme-default": "po-theme-default",
   "@totvs": "@portinari"
 }


### PR DESCRIPTION
Parece que o migrador não achava a dependência por não haver o ``^`` na seguinte string ``const previousVersion = '4';``.