### PR TITLE
issue/1: Correção do regex de validação da versão do THF para migração

### DIFF
--- a/src/migration/index.js
+++ b/src/migration/index.js
@@ -33,10 +33,11 @@ function changePortinariVersion(
   dependenciesExcluded) {
 
   const packageJson = fileReader.getFileSync(packageJsonFile);
+  const previousVersionRegex = new RegExp(`^(\\^|\\~)?${previousVersion}\\..*$`);
 
   for (const dependency in packageJson.dependencies) {
     
-    if (dependency.startsWith(dependencyPrefix) && !packageJson.dependencies[dependency].startsWith(previousVersion)) {
+    if (dependency.startsWith(dependencyPrefix) && !previousVersionRegex.test(packageJson.dependencies[dependency])) {
 
       return false;
     


### PR DESCRIPTION
A validação da versão do THF para migração não estava verificando ^,
Portanto se houvesse ^4.0.0, o projeto não era atualizado para @portinari, exibindo uma mensagem.

Foi alterado o Regex de validação da versão do THF, para que verifique os símbolos ^ e ~ (caso conter) juntamente com o número 4.

issue #1