### PR TITLE
issue/2: Corrigido palavra chave thf-theme-default

### DIFF
--- a/src/migration/keyWords.json
+++ b/src/migration/keyWords.json
@@ -2165,6 +2165,6 @@
   "thf-toaster-base": "po-toaster-base",
   "thf-ui": "portinari-ui",
   "thf-theme/": "style/",
-  "thf-theme-default": "portinari-theme-default",
+  "thf-theme-default": "po-theme-default",
   "@totvs": "@portinari"
 }


### PR DESCRIPTION
Realizado o ajuste da palavra chave thf-theme-default.

antes:
``` "thf-theme-default": "portinari-theme-default" ```

atualmente:
``` "thf-theme-default": "po-theme-default" ```

Issue #2 

PR relacionada #3 