### PR TITLE
po-migration/DTHFUI-1573: não valida os pacotes @totvs/mingle e @totvs/mobile-theme

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -7,7 +7,7 @@ function start(path, options) {
   const newVersion = '1.0.0';
   const previousVersion = '4';
   const dependencyPrefix = '@totvs/';
-  const dependenciesExcluded = ['@totvs/thf-kendo', '@totvs/thf-theme-kendo', '@totvs/mobile-theme'];
+  const dependenciesExcluded = ['@totvs/mingle', '@totvs/thf-kendo', '@totvs/thf-theme-kendo', '@totvs/mobile-theme'];
 
   const srcPath = pathNode.join(path, 'src');
   const angularPath = pathNode.join(path, 'angular.json');

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -6,8 +6,7 @@ const migration = require('../migration');
 function start(path, options) {
   const newVersion = '1.0.0';
   const previousVersion = '4';
-  const dependencyPrefix = '@totvs/';
-  const dependenciesExcluded = ['@totvs/mingle', '@totvs/thf-kendo', '@totvs/thf-theme-kendo', '@totvs/mobile-theme'];
+  const dependenciesExcluded = ['@totvs/thf-kendo', '@totvs/thf-theme-kendo'];
 
   const srcPath = pathNode.join(path, 'src');
   const angularPath = pathNode.join(path, 'angular.json');
@@ -17,7 +16,7 @@ function start(path, options) {
     migration.fileReader.setup(options);
 
     const checkVersion = migration.changePortinariVersion(
-      packagePath, dependencyPrefix, previousVersion, newVersion, dependenciesExcluded);
+      packagePath, previousVersion, newVersion, dependenciesExcluded);
 
     if (checkVersion) {
       migration.convertDirectory(srcPath);

--- a/src/migration/index.js
+++ b/src/migration/index.js
@@ -35,16 +35,21 @@ function changePortinariVersion(
   const packageJson = fileReader.getFileSync(packageJsonFile);
   const previousVersionRegex = new RegExp(`^(\\^|\\~)?${previousVersion}\\..*$`);
 
+  // não deve validar se as dependencias @totvs/mingle e @totvs/mobile-theme estão na versão 4.
+  const unvalidatedDependencies = ['@totvs/mingle', '@totvs/mobile-theme'];
+
   for (const dependency in packageJson.dependencies) {
-    
-    if (dependency.startsWith(dependencyPrefix) && !previousVersionRegex.test(packageJson.dependencies[dependency])) {
+
+    if (dependency.startsWith(dependencyPrefix) &&
+        !unvalidatedDependencies.includes(dependency) &&
+        !previousVersionRegex.test(packageJson.dependencies[dependency])) {
 
       return false;
     
     } else if (dependency.startsWith(dependencyPrefix) && !dependenciesExcluded.includes(dependency)) {
       
       packageJson.dependencies[dependency] = newVersion;
-    
+
     }
   
   };

--- a/src/migration/index.js
+++ b/src/migration/index.js
@@ -1,6 +1,7 @@
 const fileSystem = require('fs');
 const path = require('path');
 const fileReader = require('./replace.js');
+const thfPackages = require('./thfPackages');
 
 // Lendo o diretório
 function convertDirectory(directory) {
@@ -27,7 +28,6 @@ function convertDirectory(directory) {
 
 function changePortinariVersion(
   packageJsonFile,
-  dependencyPrefix,
   previousVersion,
   newVersion,
   dependenciesExcluded) {
@@ -35,24 +35,18 @@ function changePortinariVersion(
   const packageJson = fileReader.getFileSync(packageJsonFile);
   const previousVersionRegex = new RegExp(`^(\\^|\\~)?${previousVersion}\\..*$`);
 
-  // não deve validar se as dependencias @totvs/mingle e @totvs/mobile-theme estão na versão 4.
-  const unvalidatedDependencies = ['@totvs/mingle', '@totvs/mobile-theme'];
-
   for (const dependency in packageJson.dependencies) {
 
-    if (dependency.startsWith(dependencyPrefix) &&
-        !unvalidatedDependencies.includes(dependency) &&
-        !previousVersionRegex.test(packageJson.dependencies[dependency])) {
+    if (thfPackages.includes(dependency) && !previousVersionRegex.test(packageJson.dependencies[dependency])) {
 
       return false;
     
-    } else if (dependency.startsWith(dependencyPrefix) && !dependenciesExcluded.includes(dependency)) {
-      
-      packageJson.dependencies[dependency] = newVersion;
+    } else if (thfPackages.includes(dependency) && !dependenciesExcluded.includes(dependency)) {
 
+      packageJson.dependencies[dependency] = newVersion;
     }
-  
-  };
+
+  }
 
   fileReader.writeFileSync(packageJsonFile, JSON.stringify(packageJson, null, 2));
 

--- a/src/migration/replace.js
+++ b/src/migration/replace.js
@@ -68,9 +68,9 @@ function replaceFile(file) {
 function replaceByKeyWords(file) {
   const keyWordsJson = getKeyWordsJson();
 
-  // substitui o @totvs com exceção do @totvs/thf-kendo e @totvs/thf-theme-kendo
-  let newFile = file.replace(/@totvs(?!(\/thf\-theme\-kendo)|(\/thf\-kendo))/g, '@portinari');
-  
+  // substitui o @totvs com exceção do @totvs/thf-kendo, @totvs/thf-theme-kendo, @totvs/mingle e @totvs/mobile-theme
+  let newFile = file.replace(/@totvs(?!(\/thf\-theme\-kendo)|(\/thf\-kendo)|(\/mingle)|(\/mobile\-theme))/g, '@portinari');
+
   for (const keyWord in keyWordsJson) {
     // regex para pegar apenas a palavra
     const regex = new RegExp(`\\b${keyWord}\\b`, 'gm');

--- a/src/migration/replace.js
+++ b/src/migration/replace.js
@@ -68,8 +68,16 @@ function replaceFile(file) {
 function replaceByKeyWords(file) {
   const keyWordsJson = getKeyWordsJson();
 
-  // substitui o @totvs com exceção do @totvs/thf-kendo, @totvs/thf-theme-kendo, @totvs/mingle e @totvs/mobile-theme
-  let newFile = file.replace(/@totvs(?!(\/thf\-theme\-kendo)|(\/thf\-kendo)|(\/mingle)|(\/mobile\-theme))/g, '@portinari');
+  const regex = new RegExp([
+  '@totvs((\/thf\-ui)|',
+  '(\/thf\-storage)|',
+  '(\/thf\-templates)|',
+  '(\/thf\-sync)|',
+  '(\/thf\-code\-editor)|',
+  '(\/thf\-theme(?!\-kendo)))',
+  ].join(''), 'g');
+
+  let newFile = file.replace(regex, "@portinari$1");
 
   for (const keyWord in keyWordsJson) {
     // regex para pegar apenas a palavra

--- a/src/migration/thfPackages.js
+++ b/src/migration/thfPackages.js
@@ -1,0 +1,12 @@
+const packages = [
+  '@totvs/thf-code-editor',
+  '@totvs/thf-kendo',
+  '@totvs/thf-kendo-theme',
+  '@totvs/thf-storage',
+  '@totvs/thf-sync',
+  '@totvs/thf-templates',
+  '@totvs/thf-theme',
+  '@totvs/thf-ui'
+]
+
+module.exports = packages;


### PR DESCRIPTION
adiciona os pacotes @totvs/mingle e @totvs/mobile-theme como pacotes que não devem ser validados na verificação da versão 4.0.0 e não altera os caminhos dos mesmos.


Fixes DTHFUI-1573