### PR TITLE
feat(po-migration): converte X-Totvs-Screen-Lock para X-Portinari-Screen-Lock

### DIFF
--- a/src/migration/keyWords.json
+++ b/src/migration/keyWords.json
@@ -2166,5 +2166,8 @@
   "thf-ui": "portinari-ui",
   "thf-theme/": "style/",
   "thf-theme-default": "po-theme-default",
-  "@totvs": "@portinari"
+  "@totvs": "@portinari",
+  "X-Totvs-Screen-Lock": "X-Portinari-Screen-Lock",
+  "X-Totvs-No-Count-Pending-Requests": "X-Portinari-No-Count-Pending-Requests",
+  "X-Totvs-No-Error": "X-Portinari-No-Error"
 }


### PR DESCRIPTION
Converte X-Totvs-Screen-Lock para X-Portinari-Screen-Lock durante o processo de migração.

Também foi feita a conversão de:
  "X-Totvs-No-Count-Pending-Requests": "X-Portinari-No-Count-Pending-Requests",
  "X-Totvs-No-Error": "X-Portinari-No-Error"

**Simulação:**
Utilizar o conversor em um projeto THF e adicionar nele os samples do:
- Thf Http Request Interceptor
- Thf Http Interceptor

E verificar se os mesmos continuam funcionando normalmente após a conversão. 

Verificar também PR que gera o .json: https://github.com/jhonyeduardo/thf-repositories-migration-test/pull/1